### PR TITLE
fix package names in search suggestions

### DIFF
--- a/src/DocsLookup.ts
+++ b/src/DocsLookup.ts
@@ -195,7 +195,7 @@ class DocEntry extends Schema.Class<DocEntry>()({
   get subpackage() {
     const [, subpackage, suffix] = this.url.match(/github\.io\/(.+?)\/(.+?)\//)!
     return suffix !== "modules" && subpackage !== suffix
-      ? `${subpackage}-${suffix}`
+      ? subpackage === 'effect' ? suffix : `${subpackage}-${suffix}`
       : subpackage
   }
 


### PR DESCRIPTION
Currently it displays them as e.g. `@effect/effect-schema`.