### PR TITLE
fix: reference for tsconfig plugin @effect/language-service

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
       "bot/*": ["./src/*.js"]
     },
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
-    "plugins": [{ "name": "@effect/langauge-service" }]
+    "plugins": [{ "name": "@effect/language-service" }]
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Type

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The current `tsconfig.json` is incorrectly configured to utilize the `@effect/language-service` plugin due to a typo (`@effect/langauge-service`).

_Truly groundbreaking stuff_ :exploding_head: 